### PR TITLE
feat(memory): add STORM_ALLOC and STORM_NEW macros

### DIFF
--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -99,8 +99,7 @@ void SBigMul(BigData* a, BigData* b, BigData* c) {
 }
 
 void SBigNew(BigData** num) {
-    auto m = SMemAlloc(sizeof(BigData), __FILE__, __LINE__, 0x0);
-    *num = new (m) BigData();
+    *num = STORM_NEW(BigData);
 }
 
 void SBigNot(BigData* a, BigData* b) {

--- a/storm/Memory.hpp
+++ b/storm/Memory.hpp
@@ -6,6 +6,18 @@
 
 #define SMEM_FLAG_ZEROMEMORY 0x8
 
+#define STORM_ALLOC(bytes)  \
+    SMemAlloc(bytes, __FILE__, __LINE__, 0x0)
+
+#define STORM_ALLOC_ZERO(bytes) \
+    SMemAlloc(bytes, __FILE__, __LINE__, SMEM_FLAG_ZEROMEMORY)
+
+#define STORM_NEW(t)    \
+    new(SMemAlloc(sizeof(t), __FILE__, __LINE__, 0x0)) t
+
+#define STORM_NEW_ZERO(t)   \
+    new(SMemAlloc(sizeof(t), __FILE__, __LINE__, SMEM_FLAG_ZEROMEMORY)) t
+
 void* SMemAlloc(size_t bytes, const char* filename, int32_t linenumber, uint32_t flags = 0);
 
 void SMemCopy(void* dst, void* src, size_t bytes);

--- a/storm/thread/linux/Thread.cpp
+++ b/storm/thread/linux/Thread.cpp
@@ -40,8 +40,7 @@ void* SCreateThread(uint32_t (*threadProc)(void*), void* threadParam, void* a3, 
 
     uint32_t threadId = S_Thread::s_threadID++;
 
-    void* m = SMemAlloc(sizeof(SThreadParmBlock), __FILE__, __LINE__, 0x8);
-    auto params = new (m) SThreadParmBlock();
+    auto params = STORM_NEW_ZERO(SThreadParmBlock);
     params->threadProc = threadProc;
     params->threadParam = threadParam;
     params->threadID = threadId;

--- a/storm/thread/mac/Thread.mm
+++ b/storm/thread/mac/Thread.mm
@@ -40,8 +40,7 @@ void* SCreateThread(uint32_t (*threadProc)(void*), void* threadParam, void* a3, 
 
     uint32_t threadId = S_Thread::s_threadID++;
 
-    void* m = SMemAlloc(sizeof(SThreadParmBlock), __FILE__, __LINE__, 0x8);
-    auto params = new (m) SThreadParmBlock();
+    auto params = STORM_NEW_ZERO(SThreadParmBlock);
     params->threadProc = threadProc;
     params->threadParam = threadParam;
     params->threadID = threadId;

--- a/storm/thread/win/Thread.cpp
+++ b/storm/thread/win/Thread.cpp
@@ -38,8 +38,7 @@ void* SCreateThread(uint32_t (*threadProc)(void*), void* threadParam, void* a3, 
         */
     }
 
-    void* m = SMemAlloc(sizeof(SThreadParmBlock), __FILE__, __LINE__, 0x8);
-    auto params = new (m) SThreadParmBlock();
+    auto params = STORM_NEW(SThreadParmBlock);
     params->threadProc = threadProc;
     params->threadParam = threadParam;
 


### PR DESCRIPTION
This PR introduces four memory management macros:
- `STORM_ALLOC`: allocates memory with `SMemAlloc` (does not zero)
- `STORM_ALLOC_ZERO`: allocates memory with `SMemAlloc` (zeroes)
- `STORM_NEW`: calls placement new on memory allocated with `SMemAlloc` (does not zero)
- `STORM_NEW_ZERO`: calls placement new on memory allocated with `SMemAlloc` (zeroes)

There are likely a few more macros used by Storm for memory management, but this should let us clean up all the repetitive placement news littering Whoa.