### PR TITLE
feat(error): add SErrPrepareAppFatal and SErrGetErrorStr stub

### DIFF
--- a/storm/Error.hpp
+++ b/storm/Error.hpp
@@ -29,13 +29,15 @@ int32_t STORMAPI SErrDisplayError(uint32_t errorcode, const char* filename, int3
 
 int32_t STORMCDECL SErrDisplayErrorFmt(uint32_t errorcode, const char* filename, int32_t linenumber, int32_t recoverable, uint32_t exitcode, const char* format, ...);
 
+int32_t STORMAPI SErrGetErrorStr(uint32_t errorcode, char* buffer, uint32_t bufferchars);
+
+uint32_t STORMAPI SErrGetLastError();
+
 int32_t STORMAPI SErrIsDisplayingError();
 
 void STORMAPI SErrPrepareAppFatal(const char* filename, int32_t linenumber);
 
 void STORMAPI SErrSetLastError(uint32_t errorcode);
-
-uint32_t STORMAPI SErrGetLastError();
 
 void STORMAPI SErrSuppressErrors(int32_t suppress);
 

--- a/test/Error.cpp
+++ b/test/Error.cpp
@@ -23,6 +23,15 @@ TEST_CASE("SErrDisplayErrorFmt", "[error]") {
     }
 }
 
+TEST_CASE("SErrGetErrorStr", "[error]") {
+    SECTION("clears result buffer") {
+        // Use a fake error to almost guarantee it won't translate
+        char buffer[32] = "memes";
+        CHECK(SErrGetErrorStr(0x12345678, buffer, sizeof(buffer)) == 0);
+        CHECK(std::string(buffer) == "");
+    }
+}
+
 TEST_CASE("SErrIsDisplayingError", "[error]") {
     SECTION("returns false by default") {
         CHECK_FALSE(SErrIsDisplayingError());

--- a/test/stormdll/storm.def
+++ b/test/stormdll/storm.def
@@ -277,7 +277,7 @@ EXPORTS
     ; Error
     ;SErrDestroy                   @460 NONAME
     SErrDisplayError              @461 NONAME
-    ;SErrGetErrorStr               @462 NONAME
+    SErrGetErrorStr               @462 NONAME
     SErrGetLastError              @463 NONAME
     ;SErrRegisterMessageSource     @464 NONAME
     SErrSetLastError              @465 NONAME

--- a/test/stormdll/stormstubs.cpp
+++ b/test/stormdll/stormstubs.cpp
@@ -38,10 +38,11 @@ void STORMAPI SBigToUnsigned(BigData*, uint32_t*) {}
 void STORMCDECL SErrDisplayAppFatal(const char* format, ...) {}
 int32_t STORMAPI SErrDisplayError(uint32_t, const char*, int32_t, const char*, int32_t, uint32_t) { return 0; }
 int32_t STORMCDECL SErrDisplayErrorFmt(uint32_t, const char*, int32_t, int32_t, uint32_t, const char*, ...) { return 0; }
+int32_t STORMAPI SErrGetErrorStr(uint32_t, char*, uint32_t) { return 0; }
+uint32_t STORMAPI SErrGetLastError() { return 0; }
 int32_t STORMAPI SErrIsDisplayingError() { return 0; }
 void STORMAPI SErrPrepareAppFatal(const char*, int32_t) {}
 void STORMAPI SErrSetLastError(uint32_t) {}
-uint32_t STORMAPI SErrGetLastError() { return 0; }
 void STORMAPI SErrSuppressErrors(int32_t) {}
 
 #include <storm/Event.hpp>

--- a/test/stormdll/stormstubs.cpp
+++ b/test/stormdll/stormstubs.cpp
@@ -39,10 +39,11 @@ void STORMAPI SBigToUnsigned(BigData*, uint32_t*) {}
 void STORMCDECL SErrDisplayAppFatal(const char* format, ...) {}
 int32_t STORMAPI SErrDisplayError(uint32_t, const char*, int32_t, const char*, int32_t, uint32_t) { return 0; }
 int32_t STORMCDECL SErrDisplayErrorFmt(uint32_t, const char*, int32_t, int32_t, uint32_t, const char*, ...) { return 0; }
+int32_t STORMAPI SErrGetErrorStr(uint32_t, char*, uint32_t) { return 0; }
+uint32_t STORMAPI SErrGetLastError() { return 0; }
 int32_t STORMAPI SErrIsDisplayingError() { return 0; }
 void STORMAPI SErrPrepareAppFatal(const char*, int32_t) {}
 void STORMAPI SErrSetLastError(uint32_t) {}
-uint32_t STORMAPI SErrGetLastError() { return 0; }
 void STORMAPI SErrSuppressErrors(int32_t) {}
 
 #include <storm/Event.hpp>


### PR DESCRIPTION
Test also runs on SC 1.17 storm.dll.

I don't think I can test SErrPrepareAppFatal without hacking exit somehow.