### PR TITLE
feat(message): add SMsg functions

### DIFF
--- a/storm/Core.cpp
+++ b/storm/Core.cpp
@@ -1,5 +1,6 @@
 #include "Core.hpp"
 #include "Event.hpp"
+#include "Message.hpp"
 #include "Region.hpp"
 #include "String.hpp"
 #include "Transparency.hpp"
@@ -13,7 +14,7 @@ int32_t STORMAPI StormDestroy() {
     // SVidDestroy();       // SC 1.17
     // SDrawDestroy();      // SC 1.17
     SRgnDestroy();          // WoW 3.3.5 (win), SC 1.17
-    // SMsgDestroy();       // WoW 3.3.5 (win), SC 1.17
+    SMsgDestroy();          // WoW 3.3.5 (win), SC 1.17
     // SNetDestroy();       // SC 1.17
     SEvtDestroy();          // WoW 3.3.5 (win)
     // SBltDestroy();       // SC 1.17

--- a/storm/Core.hpp
+++ b/storm/Core.hpp
@@ -16,6 +16,7 @@
 #if !defined(WHOA_SYSTEM_WIN)
 typedef void* HANDLE;
 typedef void* LPOVERLAPPED;
+typedef struct HWND__* HWND;
 #endif
 
 int32_t STORMAPI StormDestroy();

--- a/storm/Message.cpp
+++ b/storm/Message.cpp
@@ -1,0 +1,228 @@
+#include "Message.hpp"
+
+#include "Error.hpp"
+#include "Event.hpp"
+#include "List.hpp"
+#include "region/Types.hpp"
+
+#if defined(WHOA_SYSTEM_WIN)
+#include <Windows.h>
+#else
+#ifndef WM_KEYDOWN
+#define WM_NCDESTROY 0x82
+#define WM_KEYDOWN 0x100
+#define WM_KEYUP 0x101
+#define WM_COMMAND 0x111
+#define WM_SYSCOMMAND 0x112
+#endif
+#endif
+
+#ifndef MAKEFOURCC
+#define MAKEFOURCC(a,b,c,d) ((a << 24) | (b << 16) | (c << 8) | (d))
+#endif
+
+#define REGISTERTYPE_BASE MAKEFOURCC('S', 'M', 'S', 'G')
+#define REGISTERTYPE_MESSAGE    (REGISTERTYPE_BASE)
+#define REGISTERTYPE_COMMAND    (REGISTERTYPE_BASE+1)
+#define REGISTERTYPE_SYSCOMMAND (REGISTERTYPE_BASE+2)
+#define REGISTERTYPE_KEYDOWN    (REGISTERTYPE_BASE+3)
+#define REGISTERTYPE_KEYUP      (REGISTERTYPE_BASE+4)
+
+struct WNDREC : public TSLinkedNode<WNDREC> {
+    HWND window;
+};
+
+STORM_LIST(WNDREC) s_wndlist;
+RECT s_defaultwindowrect;
+HWND s_defaultwindow;
+
+WNDREC* FindWindow(HWND window);
+
+void AddWindow(HWND window) {
+    s_wndlist.NewNode(STORM_LIST_TAIL, 0, 0)->window = window;
+}
+
+void DeleteWindow(HWND window) {
+    if (window == s_defaultwindow) {
+        s_defaultwindowrect = {};
+        s_defaultwindow = nullptr;
+    }
+    WNDREC* ptr = FindWindow(window);
+    if (ptr) {
+        SEvtUnregisterType(REGISTERTYPE_MESSAGE, reinterpret_cast<uint32_t>(window));
+        SEvtUnregisterType(REGISTERTYPE_COMMAND, reinterpret_cast<uint32_t>(window));
+        SEvtUnregisterType(REGISTERTYPE_SYSCOMMAND, reinterpret_cast<uint32_t>(window));
+        SEvtUnregisterType(REGISTERTYPE_KEYUP, reinterpret_cast<uint32_t>(window));
+        SEvtUnregisterType(REGISTERTYPE_KEYDOWN, reinterpret_cast<uint32_t>(window));
+        s_wndlist.DeleteNode(ptr);
+    }
+}
+
+WNDREC* FindWindow(HWND window) {
+    for (WNDREC* curr = s_wndlist.Head(); curr; curr = curr->Next()) {
+        if (curr->window == window) return curr;
+    }
+    return nullptr;
+}
+
+int32_t InternalRegister(uint32_t type, HWND window, uint32_t id, SMSGHANDLER handler) {
+    STORM_VALIDATE_BEGIN;
+    STORM_VALIDATE(handler);
+    STORM_VALIDATE_END;
+
+    if (!FindWindow(window)) {
+        AddWindow(window);
+    }
+    return SEvtRegisterHandler(type, reinterpret_cast<uint32_t>(window), id, 0, reinterpret_cast<SEVTHANDLER>(handler));
+}
+
+int32_t InternalUnregister(uint32_t type, HWND window, uint32_t id, SMSGHANDLER handler) {
+    if (!FindWindow(window)) {
+        AddWindow(window);
+    }
+    return SEvtUnregisterHandler(type, reinterpret_cast<uint32_t>(window), id, reinterpret_cast<SEVTHANDLER>(handler));
+}
+
+int32_t STORMAPI SMsgBreakHandlerChain(PARAMS* params) {
+    return SEvtBreakHandlerChain(params);
+}
+
+int32_t STORMAPI SMsgDestroy() {
+    while (WNDREC* wnd = s_wndlist.Head()) {
+        DeleteWindow(wnd->window);
+    }
+    return 1;
+}
+
+int32_t STORMAPI SMsgDispatchMessage(HWND window, uint32_t message, uint32_t wparam, int32_t lparam, int32_t* useresult, int32_t* result) {
+    if (useresult) *useresult = 0;
+    if (result) *result = 0;
+
+    PARAMS params;
+    params.window = window;
+    params.message = message;
+    params.wparam = wparam;
+    params.lparam = lparam;
+    params.notifycode = message == WM_COMMAND ? (wparam >> 16) : 0;
+    params.useresult = 0;
+    params.result = 0;
+
+    HWND wnd = window;
+    while(1) {
+        SEvtDispatch(REGISTERTYPE_MESSAGE, reinterpret_cast<uint32_t>(wnd), message, &params);
+        switch(message) {
+        case WM_KEYDOWN:
+            SEvtDispatch(REGISTERTYPE_KEYDOWN, reinterpret_cast<uint32_t>(wnd), wparam, &params);
+            break;
+        case WM_KEYUP:
+            SEvtDispatch(REGISTERTYPE_KEYUP, reinterpret_cast<uint32_t>(wnd), wparam, &params);
+            break;
+        case WM_COMMAND:
+            SEvtDispatch(REGISTERTYPE_COMMAND, reinterpret_cast<uint32_t>(wnd), wparam & 0xFFFF, &params);
+            break;
+        case WM_SYSCOMMAND:
+            SEvtDispatch(REGISTERTYPE_SYSCOMMAND, reinterpret_cast<uint32_t>(wnd), wparam, &params);
+            break;
+        }
+
+        if (!wnd || wnd != s_defaultwindow) break;
+        wnd = nullptr;
+    }
+
+    if (message == WM_NCDESTROY) {
+        DeleteWindow(window);
+    }
+
+    if (useresult) *useresult = params.useresult;
+    if (result) *result = params.result;
+    return 1;
+}
+
+HWND STORMAPI SMsgGetDefaultWindow() {
+    return s_defaultwindow;
+}
+
+int32_t STORMAPI SMsgGetDefaultWindowRect(RECT* rect) {
+    STORM_VALIDATE_BEGIN;
+    STORM_VALIDATE(rect);
+    STORM_VALIDATE_END;
+
+#if defined(WHOA_SYSTEM_WIN)
+    if (s_defaultwindowrect.left == 0 && s_defaultwindowrect.top == 0 && s_defaultwindowrect.right == 0 && s_defaultwindowrect.bottom == 0) {
+        return GetClientRect(s_defaultwindow, rect);
+    }
+#endif
+    *rect = s_defaultwindowrect;
+    return 1;
+}
+
+int32_t STORMAPI SMsgPopRegisterState(HWND window) {
+    SEvtPopState(REGISTERTYPE_COMMAND, reinterpret_cast<uint32_t>(window));
+    SEvtPopState(REGISTERTYPE_SYSCOMMAND, reinterpret_cast<uint32_t>(window));
+    SEvtPopState(REGISTERTYPE_KEYDOWN, reinterpret_cast<uint32_t>(window));
+    SEvtPopState(REGISTERTYPE_KEYUP, reinterpret_cast<uint32_t>(window));
+    SEvtPopState(REGISTERTYPE_MESSAGE, reinterpret_cast<uint32_t>(window));
+    return 1;
+}
+
+int32_t STORMAPI SMsgPushRegisterState(HWND window) {
+    SEvtPushState(REGISTERTYPE_COMMAND, reinterpret_cast<uint32_t>(window));
+    SEvtPushState(REGISTERTYPE_SYSCOMMAND, reinterpret_cast<uint32_t>(window));
+    SEvtPushState(REGISTERTYPE_KEYDOWN, reinterpret_cast<uint32_t>(window));
+    SEvtPushState(REGISTERTYPE_KEYUP, reinterpret_cast<uint32_t>(window));
+    SEvtPushState(REGISTERTYPE_MESSAGE, reinterpret_cast<uint32_t>(window));
+    return 1;
+}
+
+int32_t STORMAPI SMsgRegisterCommand(HWND window, uint32_t id, SMSGHANDLER handler) {
+    return InternalRegister(REGISTERTYPE_COMMAND, window, id, handler);
+}
+
+int32_t STORMAPI SMsgRegisterKeyDown(HWND window, uint32_t id, SMSGHANDLER handler) {
+    return InternalRegister(REGISTERTYPE_KEYDOWN, window, id, handler);
+}
+
+int32_t STORMAPI SMsgRegisterKeyUp(HWND window, uint32_t id, SMSGHANDLER handler) {
+    return InternalRegister(REGISTERTYPE_KEYUP, window, id, handler);
+}
+
+int32_t STORMAPI SMsgRegisterMessage(HWND window, uint32_t id, SMSGHANDLER handler) {
+    return InternalRegister(REGISTERTYPE_MESSAGE, window, id, handler);
+}
+
+int32_t STORMAPI SMsgRegisterSysCommand(HWND window, uint32_t id, SMSGHANDLER handler) {
+    return InternalRegister(REGISTERTYPE_SYSCOMMAND, window, id, handler);
+}
+
+int32_t STORMAPI SMsgSetDefaultWindow(HWND window) {
+    s_defaultwindow = window;
+    return 1;
+}
+
+void STORMAPI SMsgSetDefaultWindowRect(RECT* rect) {
+    STORM_VALIDATE_BEGIN;
+    STORM_VALIDATE(rect);
+    STORM_VALIDATE_END;
+
+    s_defaultwindowrect = *rect;
+}
+
+int32_t STORMAPI SMsgUnregisterCommand(HWND window, uint32_t id, SMSGHANDLER handler) {
+    return InternalUnregister(REGISTERTYPE_COMMAND, window, id, handler);
+}
+
+int32_t STORMAPI SMsgUnregisterKeyDown(HWND window, uint32_t id, SMSGHANDLER handler) {
+    return InternalUnregister(REGISTERTYPE_KEYDOWN, window, id, handler);
+}
+
+int32_t STORMAPI SMsgUnregisterKeyUp(HWND window, uint32_t id, SMSGHANDLER handler) {
+    return InternalUnregister(REGISTERTYPE_KEYUP, window, id, handler);
+}
+
+int32_t STORMAPI SMsgUnregisterMessage(HWND window, uint32_t id, SMSGHANDLER handler) {
+    return InternalUnregister(REGISTERTYPE_MESSAGE, window, id, handler);
+}
+
+int32_t STORMAPI SMsgUnregisterSysCommand(HWND window, uint32_t id, SMSGHANDLER handler) {
+    return InternalUnregister(REGISTERTYPE_SYSCOMMAND, window, id, handler);
+}

--- a/storm/Message.hpp
+++ b/storm/Message.hpp
@@ -1,0 +1,61 @@
+#ifndef STORM_MESSAGE_HPP
+#define STORM_MESSAGE_HPP
+#include "Core.hpp"
+#include "region/Types.hpp"
+
+#if defined(WHOA_SYSTEM_WIN)
+#include <Windows.h>
+#endif
+
+typedef struct _PARAMS {
+    void* window;
+    uint32_t message;
+    uint32_t wparam;
+    int32_t lparam;
+    uint32_t notifycode;
+    void* extra;
+    int32_t useresult;
+    int32_t result;
+} PARAMS;
+
+typedef void (STORMAPI* SMSGHANDLER)(PARAMS*);
+
+int32_t STORMAPI SMsgBreakHandlerChain(PARAMS* params);
+
+int32_t STORMAPI SMsgDestroy();
+
+int32_t STORMAPI SMsgDispatchMessage(HWND window, uint32_t message, uint32_t wparam, int32_t lparam, int32_t* useresult, int32_t* result);
+
+HWND STORMAPI SMsgGetDefaultWindow();
+
+int32_t STORMAPI SMsgGetDefaultWindowRect(RECT* rect);
+
+int32_t STORMAPI SMsgPopRegisterState(HWND window);
+
+int32_t STORMAPI SMsgPushRegisterState(HWND window);
+
+int32_t STORMAPI SMsgRegisterCommand(HWND window, uint32_t id, SMSGHANDLER handler);
+
+int32_t STORMAPI SMsgRegisterKeyDown(HWND window, uint32_t id, SMSGHANDLER handler);
+
+int32_t STORMAPI SMsgRegisterKeyUp(HWND window, uint32_t id, SMSGHANDLER handler);
+
+int32_t STORMAPI SMsgRegisterMessage(HWND window, uint32_t id, SMSGHANDLER handler);
+
+int32_t STORMAPI SMsgRegisterSysCommand(HWND window, uint32_t id, SMSGHANDLER handler);
+
+int32_t STORMAPI SMsgSetDefaultWindow(HWND window);
+
+void STORMAPI SMsgSetDefaultWindowRect(RECT* rect);
+
+int32_t STORMAPI SMsgUnregisterCommand(HWND window, uint32_t id, SMSGHANDLER handler);
+
+int32_t STORMAPI SMsgUnregisterKeyDown(HWND window, uint32_t id, SMSGHANDLER handler);
+
+int32_t STORMAPI SMsgUnregisterKeyUp(HWND window, uint32_t id, SMSGHANDLER handler);
+
+int32_t STORMAPI SMsgUnregisterMessage(HWND window, uint32_t id, SMSGHANDLER handler);
+
+int32_t STORMAPI SMsgUnregisterSysCommand(HWND window, uint32_t id, SMSGHANDLER handler);
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ if(WHOA_TEST_STORMDLL)
         Event.cpp
         EventTest.cpp
         Memory.cpp
+        Message.cpp
         Region.cpp
         String.cpp
         Test.cpp

--- a/test/Message.cpp
+++ b/test/Message.cpp
@@ -1,0 +1,78 @@
+#include "test/Test.hpp"
+#include "storm/Message.hpp"
+
+TEST_CASE("SMsgBreakHandlerChain", "[message]") {
+
+}
+
+TEST_CASE("SMsgDestroy", "[message]") {
+
+}
+
+TEST_CASE("SMsgDispatchMessage", "[message]") {
+
+}
+
+TEST_CASE("SMsgGetDefaultWindow", "[message]") {
+
+}
+
+TEST_CASE("SMsgGetDefaultWindowRect", "[message]") {
+
+}
+
+TEST_CASE("SMsgPopRegisterState", "[message]") {
+
+}
+
+TEST_CASE("SMsgPushRegisterState", "[message]") {
+
+}
+
+TEST_CASE("SMsgRegisterCommand", "[message]") {
+
+}
+
+TEST_CASE("SMsgRegisterKeyDown", "[message]") {
+
+}
+
+TEST_CASE("SMsgRegisterKeyUp", "[message]") {
+
+}
+
+TEST_CASE("SMsgRegisterMessage", "[message]") {
+
+}
+
+TEST_CASE("SMsgRegisterSysCommand", "[message]") {
+
+}
+
+TEST_CASE("SMsgSetDefaultWindow", "[message]") {
+
+}
+
+TEST_CASE("SMsgSetDefaultWindowRect", "[message]") {
+
+}
+
+TEST_CASE("SMsgUnregisterCommand", "[message]") {
+
+}
+
+TEST_CASE("SMsgUnregisterKeyDown", "[message]") {
+
+}
+
+TEST_CASE("SMsgUnregisterKeyUp", "[message]") {
+
+}
+
+TEST_CASE("SMsgUnregisterMessage", "[message]") {
+
+}
+
+TEST_CASE("SMsgUnregisterSysCommand", "[message]") {
+
+}

--- a/test/stormdll/storm.def
+++ b/test/stormdll/storm.def
@@ -222,15 +222,15 @@ EXPORTS
 
     ; Message handling
     ;SMsgDestroy                   @411 NONAME
-    ;SMsgDispatchMessage           @412 NONAME
-    ;SMsgDoMessageLoop             @413 NONAME
-    ;SMsgRegisterCommand           @414 NONAME
-    ;SMsgRegisterKeyDown           @415 NONAME
-    ;SMsgRegisterKeyUp             @416 NONAME
-    ;SMsgRegisterMessage           @417 NONAME
-    ;SMsgPopRegisterState          @418 NONAME
-    ;SMsgPushRegisterState         @419 NONAME
-    ;SMsgRegisterSysCommand        @420 NONAME
+    SMsgDispatchMessage            @412 NONAME
+    ;SMsgDoMessageLoop              @413 NONAME
+    SMsgRegisterCommand            @414 NONAME
+    SMsgRegisterKeyDown            @415 NONAME
+    SMsgRegisterKeyUp              @416 NONAME
+    SMsgRegisterMessage            @417 NONAME
+    SMsgPopRegisterState           @418 NONAME
+    SMsgPushRegisterState          @419 NONAME
+    SMsgRegisterSysCommand         @420 NONAME
 
     ; Registry
     ;SRegLoadData                  @421 NONAME
@@ -330,15 +330,15 @@ EXPORTS
     SStrUpper                     @510 NONAME
 
     ; Messages extended
-    ;SMsgBreakHandlerChain         @511 NONAME
-    ;SMsgUnregisterCommand         @512 NONAME
-    ;SMsgUnregisterKeyDown         @513 NONAME
-    ;SMsgUnregisterKeyUp           @514 NONAME
-    ;SMsgUnregisterMessage         @515 NONAME
-    ;SMsgGetGenericWndProc         @516 NONAME
-    ;SMsgSetDefaultWindow          @517 NONAME
-    ;SMsgGetDefaultWindow          @518 NONAME
-    ;SMsgUnregisterSysCommand      @519 NONAME
+    SMsgBreakHandlerChain          @511 NONAME
+    SMsgUnregisterCommand          @512 NONAME
+    SMsgUnregisterKeyDown          @513 NONAME
+    SMsgUnregisterKeyUp            @514 NONAME
+    SMsgUnregisterMessage          @515 NONAME
+    ;SMsgGetGenericWndProc          @516 NONAME
+    SMsgSetDefaultWindow           @517 NONAME
+    SMsgGetDefaultWindow           @518 NONAME
+    SMsgUnregisterSysCommand       @519 NONAME
 
     ; Regions
     SRgnClear                     @521 NONAME
@@ -404,8 +404,8 @@ EXPORTS
     SStrVPrintf                   @581 NONAME
 
     ; More drawing
-    ;SMsgSetDefaultWindowRect      @582 NONAME
-    ;SMsgGetDefaultWindowRect      @583 NONAME
+    SMsgSetDefaultWindowRect      @582 NONAME
+    SMsgGetDefaultWindowRect      @583 NONAME
 
     ; More strings
     ?SStrStr@@YGPADPADPBD@Z       @584 NONAME

--- a/test/stormdll/stormstubs.cpp
+++ b/test/stormdll/stormstubs.cpp
@@ -66,6 +66,28 @@ void STORMAPI SMemMove(void*, void*, size_t) {}
 void* STORMAPI SMemReAlloc(void*, size_t, const char*, int32_t, uint32_t) { return 0; }
 void STORMAPI SMemZero(void*, size_t) {}
 
+#include <storm/Message.hpp>
+
+int32_t STORMAPI SMsgBreakHandlerChain(PARAMS*) { return 0; }
+int32_t STORMAPI SMsgDestroy() { return 0; }
+int32_t STORMAPI SMsgDispatchMessage(HWND, uint32_t, uint32_t, int32_t, int32_t*, int32_t*) { return 0; }
+HWND STORMAPI SMsgGetDefaultWindow() { return 0; }
+int32_t STORMAPI SMsgGetDefaultWindowRect(RECT*) { return 0; }
+int32_t STORMAPI SMsgPopRegisterState(HWND) { return 0; }
+int32_t STORMAPI SMsgPushRegisterState(HWND) { return 0; }
+int32_t STORMAPI SMsgRegisterCommand(HWND, uint32_t, SMSGHANDLER) { return 0; }
+int32_t STORMAPI SMsgRegisterKeyDown(HWND, uint32_t, SMSGHANDLER) { return 0; }
+int32_t STORMAPI SMsgRegisterKeyUp(HWND, uint32_t, SMSGHANDLER) { return 0; }
+int32_t STORMAPI SMsgRegisterMessage(HWND, uint32_t, SMSGHANDLER) { return 0; }
+int32_t STORMAPI SMsgRegisterSysCommand(HWND, uint32_t, SMSGHANDLER) { return 0; }
+int32_t STORMAPI SMsgSetDefaultWindow(HWND) { return 0; }
+void STORMAPI SMsgSetDefaultWindowRect(RECT*) { return; }
+int32_t STORMAPI SMsgUnregisterCommand(HWND, uint32_t, SMSGHANDLER) { return 0; }
+int32_t STORMAPI SMsgUnregisterKeyDown(HWND, uint32_t, SMSGHANDLER) { return 0; }
+int32_t STORMAPI SMsgUnregisterKeyUp(HWND, uint32_t, SMSGHANDLER) { return 0; }
+int32_t STORMAPI SMsgUnregisterMessage(HWND, uint32_t, SMSGHANDLER) { return 0; }
+int32_t STORMAPI SMsgUnregisterSysCommand(HWND, uint32_t, SMSGHANDLER) { return 0; }
+
 #include <storm/Region.hpp>
 
 void STORMAPI SRgnClear(HSRGN) {}


### PR DESCRIPTION
Exists in WoW but I think it's only used by Diablo II.

I can't be bothered to slog through testing it and we won't be using it, so just putting it up for visibility in case the D2 people want it.

|Ordinal|Name|Implemented|Tested|
|--------|-------|-------|-------|
|411|SMsgDestroy|✓||
|412|SMsgDispatchMessage|✓||
|414|SMsgRegisterCommand|✓||
|415|SMsgRegisterKeyDown|✓||
|416|SMsgRegisterKeyUp|✓||
|417|SMsgRegisterMessage|✓||
|418|SMsgPopRegisterState|✓||
|419|SMsgPushRegisterState|✓||
|420|SMsgRegisterSysCommand|✓||
|511|SMsgBreakHandlerChain|✓||
|512|SMsgUnregisterCommand|✓||
|513|SMsgUnregisterKeyDown|✓||
|514|SMsgUnregisterKeyUp|✓||
|515|SMsgUnregisterMessage|✓||
|517|SMsgSetDefaultWindow|✓||
|518|SMsgGetDefaultWindow|✓||
|519|SMsgUnregisterSysCommand|✓||
|582|SMsgSetDefaultWindowRect|✓||
|583|SMsgGetDefaultWindowRect|✓||


`SMsgDoMessageLoop` and `SMsgGetGenericWndProc` are excluded because they are both (a) not used and (b) extremely tied to Windows APIs, more than just a single call or type.

I'm aware that a 64-bit compile will cast the HWND to 32 bits but SEvt on 64-bit WC3 uses 32-bit arguments...